### PR TITLE
Ignoring "None" value from pyping whenever IP is not available

### DIFF
--- a/do_latency/ping.py
+++ b/do_latency/ping.py
@@ -9,4 +9,4 @@ def do_ping(host, count=10, timeout=10, udp=False, hook=None):
         results.append(ping(host, timeout, udp=udp))
         if hook is not None:
             hook()
-    return "{:.3f}".format(sum(results) / count)
+    return "{:.3f}".format(sum([result for result in results if result is not None]) / count)


### PR DESCRIPTION
Fixed error if IP is not reachable:
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'

by filtering "None" value and removing it from list

btw thx for the tool! going to check the best latency for my VPN setup and found this :)

```
ppetrov@dev: ~ $ python --version
Python 2.7.12
```