### PR TITLE
(fix) Python 3 exception handling syntax.

### DIFF
--- a/do_latency/download.py
+++ b/do_latency/download.py
@@ -18,7 +18,7 @@ def do_download(url, hook=None):
     returnFormat = "{:06.3f}"
     try:
         http_handler = urllib2.urlopen(url)
-    except URLError, e:
+    except URLError as e:
         if hook is not None:
             hook(None, "'{}': {}".format(url, e.reason))
         return returnFormat.format(0)


### PR DESCRIPTION
Hello @dizballanze,

this PR fixes Python 3 exception handling syntax.

The original error was:
```
~/.local/bin/do-latency            
Traceback (most recent call last):
  File "~/.local/bin/do-latency", line 7, in <module>
    from do_latency.do_latency import main
  File "~/.local/lib/python3.6/site-packages/do_latency/do_latency.py", line 10, in <module>
    from .download import do_download
  File "~/.local/lib/python3.6/site-packages/do_latency/download.py", line 21
    except URLError, e:
                   ^
SyntaxError: invalid syntax
```

Thanks, Georgy